### PR TITLE
feat; Improve logging

### DIFF
--- a/internal/helpers/cleanup/cleanup.go
+++ b/internal/helpers/cleanup/cleanup.go
@@ -1,0 +1,103 @@
+package cleanup
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"sync/atomic"
+	"syscall"
+
+	"github.com/lattesec/ctfjx/internal/helpers/nopanic"
+	"github.com/lattesec/ctfjx/pkg/log"
+)
+
+type CleanupFunc func() error
+
+var (
+	once sync.Once
+
+	errMu      sync.Mutex
+	errorIdGen uint64
+	errorFns   = make(map[uint64]CleanupFunc)
+
+	mu           sync.Mutex
+	cleanupIdGen uint64
+	cleanupFns   = make(map[uint64]CleanupFunc)
+)
+
+// Register registers a cleanup function
+// that is called on exit
+func Register(fn CleanupFunc) uint64 {
+	id := atomic.AddUint64(&cleanupIdGen, 1)
+	mu.Lock()
+	cleanupFns[id] = fn
+	mu.Unlock()
+	return id
+}
+
+func Unregister(id uint64) {
+	mu.Lock()
+	delete(cleanupFns, id)
+	mu.Unlock()
+}
+
+// RegisterError registers an error cleanup function
+// that is called on error exit
+func RegisterError(fn CleanupFunc) uint64 {
+	id := atomic.AddUint64(&errorIdGen, 1)
+	errMu.Lock()
+	errorFns[id] = fn
+	errMu.Unlock()
+	return id
+}
+
+func UnregisterError(id uint64) {
+	errMu.Lock()
+	delete(errorFns, id)
+	errMu.Unlock()
+}
+
+func RunErrorCleanup() {
+	errMu.Lock()
+	fns := make([]CleanupFunc, 0, len(errorFns))
+	for _, fn := range errorFns {
+		fns = append(fns, fn)
+	}
+	errorFns = make(map[uint64]CleanupFunc)
+	atomic.StoreUint64(&errorIdGen, 0)
+	errMu.Unlock()
+	for i, fn := range fns {
+		name := fmt.Sprintf("error cleanup %d", i)
+		if err := nopanic.NoPanicRun(name, fn); err != nil {
+			log.Errorf("%s failed: %v", name, err)
+		}
+	}
+}
+
+func RunCleanup() {
+	mu.Lock()
+	fns := make([]CleanupFunc, 0, len(cleanupFns))
+	for _, fn := range cleanupFns {
+		fns = append(fns, fn)
+	}
+	cleanupFns = make(map[uint64]CleanupFunc)
+	atomic.StoreUint64(&cleanupIdGen, 0)
+	mu.Unlock()
+	for i, fn := range fns {
+		name := fmt.Sprintf("cleanup %d", i)
+		if err := nopanic.NoPanicRun(name, fn); err != nil {
+			log.Errorf("%s failed: %v", name, err)
+		}
+	}
+}
+
+func Listen() {
+	once.Do(func() {
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+		<-sigs
+		RunErrorCleanup()
+		RunCleanup()
+	})
+}

--- a/internal/helpers/cleanup/cleanup.go
+++ b/internal/helpers/cleanup/cleanup.go
@@ -9,7 +9,6 @@ import (
 	"syscall"
 
 	"github.com/lattesec/ctfjx/internal/helpers/nopanic"
-	"github.com/lattesec/ctfjx/pkg/log"
 )
 
 type CleanupFunc func() error
@@ -70,7 +69,7 @@ func RunErrorCleanup() {
 	for i, fn := range fns {
 		name := fmt.Sprintf("error cleanup %d", i)
 		if err := nopanic.NoPanicRun(name, fn); err != nil {
-			log.Errorf("%s failed: %v", name, err)
+			fmt.Fprintf(os.Stderr, "%s failed: %v\n", name, err)
 		}
 	}
 }
@@ -87,7 +86,7 @@ func RunCleanup() {
 	for i, fn := range fns {
 		name := fmt.Sprintf("cleanup %d", i)
 		if err := nopanic.NoPanicRun(name, fn); err != nil {
-			log.Errorf("%s failed: %v", name, err)
+			fmt.Fprintf(os.Stderr, "%s failed: %v\n", name, err)
 		}
 	}
 }

--- a/internal/helpers/debughelper/trace.go
+++ b/internal/helpers/debughelper/trace.go
@@ -1,0 +1,23 @@
+package debughelper
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+)
+
+func TraceCaller() string {
+	pc, file, line, ok := runtime.Caller(3)
+	if !ok {
+		return "???"
+	}
+	short := filepath.Base(file)
+	fn := runtime.FuncForPC(pc).Name()
+	return fmt.Sprintf("trace: %s:%d (%s)", short, line, fn)
+}
+
+func TraceStack() string {
+	buf := make([]byte, 4<<10)
+	n := runtime.Stack(buf, false)
+	return "stack:\n" + string(buf[:n])
+}

--- a/internal/helpers/nopanic/nopanic.go
+++ b/internal/helpers/nopanic/nopanic.go
@@ -1,0 +1,52 @@
+package nopanic
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+func run[T any](name string, rerun bool, fn func() T) (out T) {
+	for {
+		var panicked bool
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					fmt.Fprintf(os.Stderr, "panic in %s: %v\n", name, r)
+					panicked = true
+				}
+			}()
+
+			out = fn()
+		}()
+
+		if !panicked || !rerun {
+			return
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func NoPanicRun[T any](name string, fn func() T) (out T) {
+	return run(name, false, fn)
+}
+
+func NoPanicRunVoid(name string, fn func()) {
+	run(name, false, func() any {
+		fn()
+		return nil
+	})
+}
+
+func NoPanicReRun[T any](name string, fn func() T) (out T) {
+	return run(name, true, fn)
+}
+
+func NoPanicReRunVoid(name string, fn func()) {
+	run(name, true, func() any {
+		fn()
+		return nil
+	})
+}

--- a/internal/socket/main_test.go
+++ b/internal/socket/main_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if err := log.Init("", log.TRACE); err != nil {
+	if err := log.Init("", "", log.TRACE); err != nil {
 		panic(err)
 	}
 	os.Exit(m.Run())

--- a/internal/socket/main_test.go
+++ b/internal/socket/main_test.go
@@ -8,7 +8,11 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if err := log.Init("", "", log.TRACE); err != nil {
+	logger := log.NewLogger("test")
+	_ = logger.SetLevel(log.TRACE)
+	log.DefaultLogger.Store(logger)
+
+	if err := logger.Start(); err != nil {
 		panic(err)
 	}
 	os.Exit(m.Run())

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -8,12 +8,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/lattesec/ctfjx/internal/helpers/debughelper"
 	"github.com/lattesec/ctfjx/internal/helpers/nopanic"
 )
 
@@ -273,22 +273,6 @@ func openLogFile(path string) (*os.File, error) {
 	return os.OpenFile(filepath.Clean(path), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 }
 
-func traceCaller() string {
-	pc, file, line, ok := runtime.Caller(3)
-	if !ok {
-		return "???"
-	}
-	short := filepath.Base(file)
-	fn := runtime.FuncForPC(pc).Name()
-	return fmt.Sprintf("trace: %s:%d (%s)", short, line, fn)
-}
-
-func traceStack() string {
-	buf := make([]byte, 4<<10)
-	n := runtime.Stack(buf, false)
-	return "stack:\n" + string(buf[:n])
-}
-
 func log(lvl Level, msg string) {
 	mu.RLock()
 	if lvl < logLevel {
@@ -300,8 +284,8 @@ func log(lvl Level, msg string) {
 
 	if logLevel == TRACE && (lvl == TRACE || lvl == ERROR) {
 		lines = append(lines,
-			fmt.Sprintf("%s [TRACE] %s", ts, traceCaller()),
-			fmt.Sprintf("%s [TRACE] %s", ts, traceStack()),
+			fmt.Sprintf("%s [TRACE] %s", ts, debughelper.TraceCaller()),
+			fmt.Sprintf("%s [TRACE] %s", ts, debughelper.TraceStack()),
 		)
 	}
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -78,12 +78,14 @@ func Init(dir, filename string, lvl Level) error {
 	closeCh = make(chan struct{})
 
 	logFileDir = filepath.Clean(dir)
-	logFilename = strings.TrimSuffix(filepath.Base(filename), ".log")
+	logFilename = filepath.Clean(strings.TrimSuffix(filepath.Base(filename), ".log"))
 
 	if logFileDir != "." && logFilename == "." {
 		return ErrMissingLogFilename
 	}
-	logFilename += ".log"
+	if logFilename != "." {
+		logFilename += ".log"
+	}
 	mu.Unlock()
 
 	if logFilename != "." {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,20 +1,10 @@
 package log
 
 import (
-	"bytes"
-	"compress/gzip"
 	"errors"
 	"fmt"
-	"io"
 	"os"
-	"path/filepath"
-	"strings"
-	"sync"
 	"sync/atomic"
-	"time"
-
-	"github.com/lattesec/ctfjx/internal/helpers/debughelper"
-	"github.com/lattesec/ctfjx/internal/helpers/nopanic"
 )
 
 // Log Level
@@ -35,286 +25,30 @@ const (
 var (
 	levelNames = [6]string{"TRACE", "DEBUG", "INFO", "WARN", "ERROR", "QUIET"}
 
-	logLevel Level = WARN
+	DefaultLogger atomic.Pointer[Logger]
 
-	logFilename string
-	logFileDir  string
-	logfilePtr  atomic.Pointer[os.File]
-
-	stdout  io.Writer = os.Stdout
-	stderr  io.Writer = os.Stderr
-	maxSize int64     = 10 << 20 // 10MB
-
-	logCh     = make(chan string, 1<<20) // The first character of the string will be 0 or 1. 0=stdout, 1=stderr
-	logfileCh = make(chan string, 1<<20) // The first character of the string will be 0 or 1. 0=stdout, 1=stderr
-	closeCh   chan struct{}
-
-	mu     sync.RWMutex
-	muFile sync.RWMutex
-
-	ErrAlreadyInitialized        = errors.New("already initialized")
+	ErrAlreadyStarted            = errors.New("already started")
 	ErrInvalidLogLevel           = errors.New("invalid log level")
 	ErrMissingLogFilename        = errors.New("missing log filename")
 	ErrNoLogFileConfigured       = errors.New("no log file configured")
 	ErrFoundDirWhenExpectingFile = errors.New("found directory when expecting file")
 )
 
-func GetLevel() Level {
-	mu.RLock()
-	defer mu.RUnlock()
-	return logLevel
+func init() {
+	DefaultLogger.Store(NewLogger("default"))
 }
 
-func Init(dir, filename string, lvl Level) error {
-	mu.Lock()
-	if lvl < TRACE || lvl > QUIET {
-		return ErrInvalidLogLevel
-	}
-	logLevel = lvl
-
-	if closeCh != nil {
-		return ErrAlreadyInitialized
-	}
-	closeCh = make(chan struct{})
-
-	logFileDir = filepath.Clean(dir)
-	logFilename = filepath.Clean(strings.TrimSuffix(filepath.Base(filename), ".log"))
-
-	if logFileDir != "." && logFilename == "." {
-		return ErrMissingLogFilename
-	}
-	if logFilename != "." {
-		logFilename += ".log"
-	}
-	mu.Unlock()
-
-	if logFilename != "." {
-		go nopanic.NoPanicReRunVoid("log file writer", fileWriter)
-		go nopanic.NoPanicReRunVoid("log file rotater", logRotater)
-	}
-
-	go nopanic.NoPanicReRunVoid("log I/O writer", logWriter)
-
-	return nil
-}
-
-func Close() {
-	mu.Lock()
-	defer mu.Unlock()
-	close(closeCh)
-	closeLogFile()
-}
-
-func closeLogFile() {
-	muFile.Lock()
-	defer muFile.Unlock()
-	close(logfileCh)
-	ptr := logfilePtr.Load()
-	if ptr != nil {
-		_ = ptr.Close()
-		logfilePtr.Store(nil)
-	}
-}
-
-func logWriter() {
-	for {
-		select {
-		case line := <-logCh:
-			if line[0] == '0' {
-				fmt.Fprint(stdout, line[1:])
-			} else {
-				fmt.Fprint(stderr, line[1:])
-			}
-		case <-closeCh:
-			return
-		}
-	}
-}
-
-func fileWriter() {
-	muFile.Lock()
-	if logfileCh == nil {
-		logfileCh = make(chan string, 1<<20)
-	}
-	muFile.Unlock()
-
-	logfile, err := ensureLogFile()
-	if err != nil {
-		Errorln("failed to open log file:", err)
-		return
-	}
-	logfilePtr.Store(logfile)
-
-	for {
-		select {
-		case line := <-logfileCh:
-			muFile.Lock()
-			_, err := logfilePtr.Load().WriteString(line[1:])
-			muFile.Unlock()
-			if err != nil {
-				Errorln("failed to write to log file:", err)
-				return
-			}
-		case <-closeCh:
-			return
-		}
-	}
-}
-
-func logRotater() {
-	ticker := time.NewTicker(time.Minute)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			mu.RLock()
-			logPath := filepath.Join(logFileDir, logFilename)
-			mu.RUnlock()
-
-			info, err := os.Stat(logPath)
-			if err != nil {
-				if os.IsNotExist(err) {
-					if _, err := ensureLogFile(); err != nil {
-						Errorln("failed to recreate missing log file, killing rotation:", err)
-						return
-					}
-					continue
-				}
-				Errorln("failed to stat log file:", err)
-				return
-			}
-
-			if info.Size() <= maxSize {
-				continue
-			}
-
-			muFile.Lock()
-
-			rotatedName := fmt.Sprintf("%s-%s.gz", logFilename, time.Now().UTC().Format("2006-01-02_15-04-05"))
-			rotatedPath := filepath.Join(logFileDir, rotatedName)
-
-			original, err := os.Open(filepath.Clean(logPath))
-			if err != nil {
-				muFile.Unlock()
-				Errorln("failed to open log for rotation:", err)
-				continue
-			}
-
-			var buf bytes.Buffer
-			gz := gzip.NewWriter(&buf)
-			_, err = io.Copy(gz, original)
-			_ = original.Close()
-			_ = gz.Close()
-			if err != nil {
-				muFile.Unlock()
-				Errorln("failed to compress rotated log:", err)
-				continue
-			}
-
-			if err := os.WriteFile(rotatedPath, buf.Bytes(), 0o600); err != nil {
-				muFile.Unlock()
-				Errorln("failed to write rotated log file:", err)
-				continue
-			}
-
-			if err := os.Truncate(logPath, 0); err != nil {
-				Errorln("failed to truncate original log after rotation:", err)
-			}
-
-			muFile.Unlock()
-
-		case <-closeCh:
-			return
-		}
-	}
-}
-
-func ensureLogDir() error {
-	if logFileDir == "." {
-		return nil
-	}
-
-	return os.MkdirAll(filepath.Clean(logFileDir), 0o700)
-}
-
-func ensureLogFile() (*os.File, error) {
-	mu.RLock()
-	defer mu.RUnlock()
-
-	if logFilename == "." {
-		return nil, ErrNoLogFileConfigured
-	}
-	if err := ensureLogDir(); err != nil {
-		return nil, err
-	}
-
-	logfileLocation := filepath.Join(logFileDir, logFilename)
-	if logfileLocation == "." {
-		return nil, ErrNoLogFileConfigured
-	}
-
-	stat, err := os.Stat(logfileLocation)
-	if err != nil && !os.IsNotExist(err) {
-		return nil, err
-	}
-	if os.IsNotExist(err) {
-		return openLogFile(logfileLocation)
-	}
-
-	if stat.IsDir() {
-		return nil, ErrFoundDirWhenExpectingFile
-	}
-
-	return openLogFile(logfileLocation)
-}
-
-func openLogFile(path string) (*os.File, error) {
-	return os.OpenFile(filepath.Clean(path), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
-}
-
-func log(lvl Level, msg string) {
-	mu.RLock()
-	if lvl < logLevel {
+func Log(msg *LogMessage) {
+	logger := DefaultLogger.Load()
+	if logger == nil {
 		return
 	}
 
-	ts := time.Now().UTC().Format(time.RFC3339Nano)
-	lines := []string{}
+	logger.Log(msg)
+}
 
-	if logLevel == TRACE && (lvl == TRACE || lvl == ERROR) {
-		lines = append(lines,
-			fmt.Sprintf("%s [TRACE] %s", ts, debughelper.TraceCaller()),
-			fmt.Sprintf("%s [TRACE] %s", ts, debughelper.TraceStack()),
-		)
-	}
-
-	lines = append(lines, fmt.Sprintf("%s [%s] %s", ts, levelNames[lvl], msg))
-	shouldWriteToIO := logLevel < QUIET
-	mu.RUnlock()
-
-	full := strings.Join(lines, "\n")
-	if lvl >= WARN {
-		full = "1" + full
-	} else {
-		full = "0" + full
-	}
-
-	if shouldWriteToIO {
-		select {
-		case logCh <- full:
-		case <-closeCh:
-		default: // drop logs when buffer is full
-		}
-	}
-
-	if logfilePtr.Load() != nil {
-		select {
-		case logfileCh <- full:
-		case <-closeCh:
-		default: // drop logs when buffer is full
-		}
-	}
+func log(level Level, msg string) {
+	Log(NewLogMessage(level, msg))
 }
 
 func Debug(v ...any) { log(DEBUG, fmt.Sprint(v...)) }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,6 +1,9 @@
 package log
 
 import (
+	"bytes"
+	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -8,7 +11,10 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
+
+	"github.com/lattesec/ctfjx/internal/helpers/nopanic"
 )
 
 // Log Level
@@ -27,67 +33,250 @@ const (
 )
 
 var (
-	mu      sync.Mutex
-	level   Level     = WARN
-	logfile *os.File  = nil
+	levelNames = [6]string{"TRACE", "DEBUG", "INFO", "WARN", "ERROR", "QUIET"}
+
+	logLevel Level = WARN
+
+	logFilename string
+	logFileDir  string
+	logfilePtr  atomic.Pointer[os.File]
+
 	stdout  io.Writer = os.Stdout
 	stderr  io.Writer = os.Stderr
+	maxSize int64     = 10 << 20 // 10MB
 
-	levelNames = [6]string{"TRACE", "DEBUG", "INFO", "WARN", "ERROR", "QUIET"}
+	logCh     = make(chan string, 1<<20) // The first character of the string will be 0 or 1. 0=stdout, 1=stderr
+	logfileCh = make(chan string, 1<<20) // The first character of the string will be 0 or 1. 0=stdout, 1=stderr
+	closeCh   chan struct{}
+
+	mu     sync.RWMutex
+	muFile sync.RWMutex
+
+	ErrAlreadyInitialized        = errors.New("already initialized")
+	ErrInvalidLogLevel           = errors.New("invalid log level")
+	ErrMissingLogFilename        = errors.New("missing log filename")
+	ErrNoLogFileConfigured       = errors.New("no log file configured")
+	ErrFoundDirWhenExpectingFile = errors.New("found directory when expecting file")
 )
 
 func GetLevel() Level {
-	return level
+	mu.RLock()
+	defer mu.RUnlock()
+	return logLevel
 }
 
-func Init(filePath string, lvl Level) error {
-	switch lvl {
-	case TRACE, DEBUG, INFO, WARN, ERROR, QUIET:
-		level = lvl
-		Debugf("set log level to %d\n", lvl)
-	default:
-		return fmt.Errorf("invalid log level: %d", lvl)
-	}
-
-	filePath = filepath.Clean(filePath)
-
-	var file *os.File
-	if filePath != "" && filePath != "." {
-		f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
-		if err != nil {
-			return err
-		}
-		file = f
-	}
-
+func Init(dir, filename string, lvl Level) error {
 	mu.Lock()
-	defer mu.Unlock()
+	if lvl < TRACE || lvl > QUIET {
+		return ErrInvalidLogLevel
+	}
+	logLevel = lvl
 
-	logfile = file
-	level = lvl
+	if closeCh != nil {
+		return ErrAlreadyInitialized
+	}
+	closeCh = make(chan struct{})
+
+	logFileDir = filepath.Clean(dir)
+	logFilename = strings.TrimSuffix(filepath.Base(filename), ".log")
+
+	if logFileDir != "." && logFilename == "." {
+		return ErrMissingLogFilename
+	}
+	logFilename += ".log"
+	mu.Unlock()
+
+	if logFilename != "." {
+		go nopanic.NoPanicReRunVoid("log file writer", fileWriter)
+		go nopanic.NoPanicReRunVoid("log file rotater", logRotater)
+	}
+
+	go nopanic.NoPanicReRunVoid("log I/O writer", logWriter)
+
 	return nil
 }
 
 func Close() {
 	mu.Lock()
 	defer mu.Unlock()
-	if logfile != nil {
-		if err := logfile.Close(); err != nil {
-			Errorf("failed to close log file: %v", err)
-		}
-		logfile = nil
+	close(closeCh)
+	closeLogFile()
+}
+
+func closeLogFile() {
+	muFile.Lock()
+	defer muFile.Unlock()
+	close(logfileCh)
+	ptr := logfilePtr.Load()
+	if ptr != nil {
+		_ = ptr.Close()
+		logfilePtr.Store(nil)
 	}
 }
 
+func logWriter() {
+	for {
+		select {
+		case line := <-logCh:
+			if line[0] == '0' {
+				fmt.Fprint(stdout, line[1:])
+			} else {
+				fmt.Fprint(stderr, line[1:])
+			}
+		case <-closeCh:
+			return
+		}
+	}
+}
+
+func fileWriter() {
+	muFile.Lock()
+	if logfileCh == nil {
+		logfileCh = make(chan string, 1<<20)
+	}
+	muFile.Unlock()
+
+	logfile, err := ensureLogFile()
+	if err != nil {
+		Errorln("failed to open log file:", err)
+		return
+	}
+	logfilePtr.Store(logfile)
+
+	for {
+		select {
+		case line := <-logfileCh:
+			muFile.Lock()
+			_, err := logfilePtr.Load().WriteString(line[1:])
+			muFile.Unlock()
+			if err != nil {
+				Errorln("failed to write to log file:", err)
+				return
+			}
+		case <-closeCh:
+			return
+		}
+	}
+}
+
+func logRotater() {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			mu.RLock()
+			logPath := filepath.Join(logFileDir, logFilename)
+			mu.RUnlock()
+
+			info, err := os.Stat(logPath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					if _, err := ensureLogFile(); err != nil {
+						Errorln("failed to recreate missing log file, killing rotation:", err)
+						return
+					}
+					continue
+				}
+				Errorln("failed to stat log file:", err)
+				return
+			}
+
+			if info.Size() <= maxSize {
+				continue
+			}
+
+			muFile.Lock()
+
+			rotatedName := fmt.Sprintf("%s-%s.gz", logFilename, time.Now().UTC().Format("2006-01-02_15-04-05"))
+			rotatedPath := filepath.Join(logFileDir, rotatedName)
+
+			original, err := os.Open(filepath.Clean(logPath))
+			if err != nil {
+				muFile.Unlock()
+				Errorln("failed to open log for rotation:", err)
+				continue
+			}
+
+			var buf bytes.Buffer
+			gz := gzip.NewWriter(&buf)
+			_, err = io.Copy(gz, original)
+			_ = original.Close()
+			_ = gz.Close()
+			if err != nil {
+				muFile.Unlock()
+				Errorln("failed to compress rotated log:", err)
+				continue
+			}
+
+			if err := os.WriteFile(rotatedPath, buf.Bytes(), 0o600); err != nil {
+				muFile.Unlock()
+				Errorln("failed to write rotated log file:", err)
+				continue
+			}
+
+			if err := os.Truncate(logPath, 0); err != nil {
+				Errorln("failed to truncate original log after rotation:", err)
+			}
+
+			muFile.Unlock()
+
+		case <-closeCh:
+			return
+		}
+	}
+}
+
+func ensureLogDir() error {
+	if logFileDir == "." {
+		return nil
+	}
+
+	return os.MkdirAll(filepath.Clean(logFileDir), 0o700)
+}
+
+func ensureLogFile() (*os.File, error) {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	if logFilename == "." {
+		return nil, ErrNoLogFileConfigured
+	}
+	if err := ensureLogDir(); err != nil {
+		return nil, err
+	}
+
+	logfileLocation := filepath.Join(logFileDir, logFilename)
+	if logfileLocation == "." {
+		return nil, ErrNoLogFileConfigured
+	}
+
+	stat, err := os.Stat(logfileLocation)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	if os.IsNotExist(err) {
+		return openLogFile(logfileLocation)
+	}
+
+	if stat.IsDir() {
+		return nil, ErrFoundDirWhenExpectingFile
+	}
+
+	return openLogFile(logfileLocation)
+}
+
+func openLogFile(path string) (*os.File, error) {
+	return os.OpenFile(filepath.Clean(path), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+}
+
 func traceCaller() string {
-	pc, file, line, ok := runtime.Caller(2)
+	pc, file, line, ok := runtime.Caller(3)
 	if !ok {
 		return "???"
 	}
-	short := file
-	if i := strings.LastIndex(file, "/"); i != -1 {
-		short = file[i+1:]
-	}
+	short := filepath.Base(file)
 	fn := runtime.FuncForPC(pc).Name()
 	return fmt.Sprintf("trace: %s:%d (%s)", short, line, fn)
 }
@@ -99,10 +288,15 @@ func traceStack() string {
 }
 
 func log(lvl Level, msg string) {
-	ts := time.Now().UTC().Format(time.RFC3339Nano)
+	mu.RLock()
+	if lvl < logLevel {
+		return
+	}
 
-	var lines []string
-	if level == TRACE && (lvl == ERROR || lvl == TRACE) {
+	ts := time.Now().UTC().Format(time.RFC3339Nano)
+	lines := []string{}
+
+	if logLevel == TRACE && (lvl == TRACE || lvl == ERROR) {
 		lines = append(lines,
 			fmt.Sprintf("%s [TRACE] %s", ts, traceCaller()),
 			fmt.Sprintf("%s [TRACE] %s", ts, traceStack()),
@@ -110,24 +304,30 @@ func log(lvl Level, msg string) {
 	}
 
 	lines = append(lines, fmt.Sprintf("%s [%s] %s", ts, levelNames[lvl], msg))
+	shouldWriteToIO := logLevel < QUIET
+	mu.RUnlock()
+
 	full := strings.Join(lines, "\n")
-
-	mu.Lock()
-	defer mu.Unlock()
-
-	if logfile != nil {
-		_, _ = logfile.WriteString(full)
+	if lvl >= WARN {
+		full = "1" + full
+	} else {
+		full = "0" + full
 	}
 
-	if lvl < level {
-		return
+	if shouldWriteToIO {
+		select {
+		case logCh <- full:
+		case <-closeCh:
+		default: // drop logs when buffer is full
+		}
 	}
 
-	switch lvl {
-	case TRACE, DEBUG, INFO:
-		fmt.Fprint(stdout, full)
-	case WARN, ERROR:
-		fmt.Fprint(stderr, full)
+	if logfilePtr.Load() != nil {
+		select {
+		case logfileCh <- full:
+		case <-closeCh:
+		default: // drop logs when buffer is full
+		}
 	}
 }
 

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,0 +1,57 @@
+package log
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type ILogger interface {
+	GetLevel() Level
+	SetLevel(level Level) error
+
+	IsRunning() bool
+	Start() error
+	Close()
+
+	Log(msg LogMessage)
+	Fatal(msg LogMessage)
+
+	GetName() string
+	SetName(name string)
+
+	GetFilename() string
+	SetFilename(filename string)
+
+	GetFileDir() string
+	SetFileDir(dir string)
+
+	GetMaxFileSize() int64
+	SetMaxFileSize(size int64)
+
+	GetStdout() io.Writer
+	SetStdout(w io.Writer)
+
+	GetStderr() io.Writer
+	SetStderr(w io.Writer)
+}
+
+type Logger struct {
+	mu     sync.RWMutex
+	muFile sync.RWMutex
+
+	level Level  // defaults to WARN
+	name  string // the name of the logger
+
+	filename    string // the filename to write logs to. leave empty to disable file writes.
+	fileDir     string // the directory to write logs to. defaults to pwd.
+	filePtr     atomic.Pointer[os.File]
+	maxFileSize int64 // exceeding this will trigger a log rotation. defaults to 10MB. set to 0 to disable rotations.
+
+	stdout io.Writer // defaults to os.Stdout.
+	stderr io.Writer // defaults to os.Stderr.
+
+	logCh     chan LogMessage // the first character of the string will be 0 or 1. 0=stdout, 1=stderr
+	logfileCh chan LogMessage // the first character of the string will be 0 or 1. 0=stdout, 1=stderr
+	closeCh   chan struct{}   // closes the log writer.
+}
+

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,9 +1,19 @@
 package log
 
 import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
+
+	"github.com/lattesec/ctfjx/internal/helpers/cleanup"
+	"github.com/lattesec/ctfjx/internal/helpers/nopanic"
 )
 
 type ILogger interface {
@@ -20,11 +30,8 @@ type ILogger interface {
 	GetName() string
 	SetName(name string)
 
-	GetFilename() string
-	SetFilename(filename string)
-
-	GetFileDir() string
-	SetFileDir(dir string)
+	GetLogfileLocation() (dir, base string)
+	SetLogfileLocation(dir, base string) error
 
 	GetMaxFileSize() int64
 	SetMaxFileSize(size int64)
@@ -46,14 +53,15 @@ type Logger struct {
 	filename    string // the filename to write logs to. leave empty to disable file writes.
 	fileDir     string // the directory to write logs to. defaults to pwd.
 	filePtr     atomic.Pointer[os.File]
-	maxFileSize int64 // exceeding this will trigger a log rotation. defaults to 10MB. set to 0 to disable rotations.
+	maxFileSize int64  // exceeding this will trigger a log rotation. defaults to 10MB. set to 0 to disable rotations.
+	cleanupId   uint64 // cleanup id
 
 	stdout io.Writer // defaults to os.Stdout.
 	stderr io.Writer // defaults to os.Stderr.
 
-	logCh     chan LogMessage // the first character of the string will be 0 or 1. 0=stdout, 1=stderr
-	logfileCh chan LogMessage // the first character of the string will be 0 or 1. 0=stdout, 1=stderr
-	closeCh   chan struct{}   // closes the log writer.
+	logCh     chan string   // the first character of the string will be 0 or 1. 0=stdout, 1=stderr
+	logfileCh chan string   // the first character of the string will be 0 or 1. 0=stdout, 1=stderr
+	closeCh   chan struct{} // closes the log writer.
 }
 
 func NewLogger(name string) *Logger {
@@ -63,7 +71,331 @@ func NewLogger(name string) *Logger {
 		closeCh:     nil,
 		stdout:      os.Stdout,
 		stderr:      os.Stderr,
-		logCh:       make(chan LogMessage, 1<<20),
-		logfileCh:   make(chan LogMessage, 1<<20),
+		logCh:       make(chan string, 1<<20),
+		logfileCh:   make(chan string, 1<<20),
+	}
+}
+
+func (l *Logger) GetLevel() Level {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.level
+}
+
+func (l *Logger) SetLevel(level Level) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if level < TRACE || level > QUIET {
+		return ErrInvalidLogLevel
+	}
+	l.level = level
+	return nil
+}
+
+func (l *Logger) IsRunning() bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.closeCh != nil
+}
+
+func (l *Logger) Start() error {
+	l.mu.Lock()
+	if l.closeCh != nil {
+		return ErrAlreadyStarted
+	}
+	l.closeCh = make(chan struct{})
+	l.cleanupId = cleanup.Register(func() error { l.Close(); return nil })
+	name := l.name
+	l.mu.Unlock()
+
+	_, base := l.GetLogfileLocation()
+	if base != "." {
+		go nopanic.NoPanicReRunVoid(name+" log file writer", l.fileWriter)
+		go nopanic.NoPanicReRunVoid(name+" log file rotater", l.logRotater)
+	}
+
+	go nopanic.NoPanicReRunVoid(name+" log I/O writer", l.logWriter)
+	return nil
+}
+
+func (l *Logger) Close() {
+	if !l.IsRunning() {
+		return
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	close(l.closeCh)
+	l.closeCh = nil
+
+	l.closeLogFile()
+	cleanup.Unregister(l.cleanupId)
+	l.cleanupId = 0
+}
+
+func (l *Logger) Log(msg *LogMessage) {
+	l.mu.RLock()
+	if msg.Level < l.level {
+		return
+	}
+
+	if (l.level == TRACE && msg.Level >= ERROR) || msg.Level == TRACE {
+		if msg.trace == "" {
+			msg.WithTraceStack()
+		}
+		if msg.caller == "" {
+			msg.WithCaller()
+		}
+	}
+
+	shouldWriteToIO := l.level < QUIET
+	l.mu.RUnlock()
+
+	logLine := msg.String()
+	if msg.Level >= WARN {
+		logLine = "1" + logLine
+	} else {
+		logLine = "0" + logLine
+	}
+
+	if shouldWriteToIO {
+		select {
+		case l.logCh <- logLine:
+		case <-l.closeCh:
+		default: // drop if buffer is full
+		}
+	}
+
+	if l.filePtr.Load() != nil {
+		select {
+		case l.logfileCh <- logLine:
+		case <-l.closeCh:
+		default: // drop if buffer is full
+		}
+	}
+}
+
+func (l *Logger) Fatal(msg *LogMessage) {
+	l.Log(msg)
+	cleanup.RunErrorCleanup()
+	cleanup.RunCleanup()
+	os.Exit(1)
+}
+
+func (l *Logger) GetName() string {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.name
+}
+
+func (l *Logger) SetName(name string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.name = name
+}
+
+func (l *Logger) GetLogfileLocation() (dir, base string) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.fileDir, l.filename
+}
+
+func (l *Logger) SetLogfileLocation(dir, base string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	dir = filepath.Clean(dir)
+	base = filepath.Clean(strings.TrimSuffix(filepath.Base(base), ".log"))
+
+	if dir != "." && base == "." {
+		return ErrMissingLogFilename
+	}
+	if base != "." {
+		base += ".log"
+	}
+
+	l.fileDir = dir
+	l.filename = base
+
+	return nil
+}
+
+func (l *Logger) closeLogFile() {
+	l.muFile.Lock()
+	defer l.muFile.Unlock()
+	close(l.logfileCh)
+	ptr := l.filePtr.Load()
+	if ptr != nil {
+		_ = ptr.Close()
+		l.filePtr.Store(nil)
+	}
+}
+
+func (l *Logger) ensureLogDir() error {
+	if l.fileDir == "." {
+		return nil
+	}
+
+	return os.MkdirAll(filepath.Clean(l.fileDir), 0o700)
+}
+
+func (l *Logger) ensureLogFile() (*os.File, error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	if l.filename == "." {
+		return nil, ErrNoLogFileConfigured
+	}
+	if err := l.ensureLogDir(); err != nil {
+		return nil, err
+	}
+
+	logfileLocation := filepath.Join(l.fileDir, l.filename)
+	if logfileLocation == "." {
+		return nil, ErrNoLogFileConfigured
+	}
+
+	stat, err := os.Stat(logfileLocation)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	if os.IsNotExist(err) {
+		return l.openLogFile()
+	}
+
+	if stat.IsDir() {
+		return nil, ErrFoundDirWhenExpectingFile
+	}
+
+	return l.openLogFile()
+}
+
+func (l *Logger) openLogFile() (*os.File, error) {
+	return os.OpenFile(
+		filepath.Join(l.fileDir, l.filename),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY,
+		0o600,
+	)
+}
+
+func (l *Logger) logWriter() {
+	for {
+		select {
+		case line := <-l.logCh:
+			if line[0] == '0' {
+				fmt.Fprint(l.stdout, line[1:])
+			} else {
+				fmt.Fprint(l.stderr, line[1:])
+			}
+		case <-l.closeCh:
+			return
+		}
+	}
+}
+
+func (l *Logger) fileWriter() {
+	l.muFile.Lock()
+	if l.logfileCh == nil {
+		l.logfileCh = make(chan string, 1<<20)
+	}
+	l.muFile.Unlock()
+
+	logfile, err := l.ensureLogFile()
+	if err != nil {
+		Errorln("failed to open log file:", err)
+		return
+	}
+	l.filePtr.Store(logfile)
+
+	for {
+		select {
+		case line := <-l.logfileCh:
+			l.muFile.Lock()
+			_, err := l.filePtr.Load().WriteString(line[1:])
+			l.muFile.Unlock()
+			if err != nil {
+				Errorln("failed to write to log file:", err)
+				return
+			}
+		case <-l.closeCh:
+			return
+		}
+	}
+}
+
+func (l *Logger) logRotater() {
+	l.mu.RLock()
+	if l.maxFileSize == 0 {
+		l.mu.RUnlock()
+		return
+	}
+	l.mu.RUnlock()
+
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			l.mu.RLock()
+			logPath := filepath.Join(l.fileDir, l.filename)
+			l.mu.RUnlock()
+
+			info, err := os.Stat(logPath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					if _, err := l.ensureLogFile(); err != nil {
+						Errorln("failed to recreate missing log file, killing rotation:", err)
+						return
+					}
+					continue
+				}
+				Errorln("failed to stat log file:", err)
+				return
+			}
+
+			if info.Size() <= l.maxFileSize {
+				continue
+			}
+
+			l.muFile.Lock()
+
+			rotatedName := fmt.Sprintf("%s-%s.gz", l.filename, time.Now().UTC().Format("2006-01-02_15-04-05"))
+			rotatedPath := filepath.Join(l.fileDir, rotatedName)
+
+			original, err := os.Open(filepath.Clean(logPath))
+			if err != nil {
+				l.muFile.Unlock()
+				Errorln("failed to open log for rotation:", err)
+				continue
+			}
+
+			var buf bytes.Buffer
+			gz := gzip.NewWriter(&buf)
+			_, err = io.Copy(gz, original)
+			_ = original.Close()
+			_ = gz.Close()
+			if err != nil {
+				l.muFile.Unlock()
+				Errorln("failed to compress rotated log:", err)
+				continue
+			}
+
+			if err := os.WriteFile(rotatedPath, buf.Bytes(), 0o600); err != nil {
+				l.muFile.Unlock()
+				Errorln("failed to write rotated log file:", err)
+				continue
+			}
+
+			if err := os.Truncate(logPath, 0); err != nil {
+				Errorln("failed to truncate original log after rotation:", err)
+			}
+
+			l.muFile.Unlock()
+
+		case <-l.closeCh:
+			return
+		}
 	}
 }

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"os"
 	"sync"
 	"sync/atomic"
 )
@@ -55,3 +56,14 @@ type Logger struct {
 	closeCh   chan struct{}   // closes the log writer.
 }
 
+func NewLogger(name string) *Logger {
+	return &Logger{
+		level:       WARN,
+		maxFileSize: 10 << 20, // 10MB
+		closeCh:     nil,
+		stdout:      os.Stdout,
+		stderr:      os.Stderr,
+		logCh:       make(chan LogMessage, 1<<20),
+		logfileCh:   make(chan LogMessage, 1<<20),
+	}
+}

--- a/pkg/log/message.go
+++ b/pkg/log/message.go
@@ -1,0 +1,58 @@
+package log
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/lattesec/ctfjx/internal/helpers/debughelper"
+)
+
+type LogMessage struct {
+	Timestamp time.Time         // timestamp
+	Level     Level             // log level
+	Msg       string            // log message
+	Meta      map[string]string // log metadata
+
+	trace  string // stack trace (optional)
+	caller string // caller (optional)
+}
+
+// NewLogMessage
+//
+// Creates a new LogMessage
+func NewLogMessage(level Level, msg string) *LogMessage {
+	return &LogMessage{
+		Timestamp: time.Now().UTC(),
+		Level:     level,
+		Msg:       msg,
+		Meta:      make(map[string]string),
+	}
+}
+
+func (lm *LogMessage) WithMeta(key string, value any) *LogMessage {
+	lm.Meta[key] = fmt.Sprintf("%v", value)
+	return lm
+}
+
+func (lm *LogMessage) WithMetaf(key, format string, v ...any) *LogMessage {
+	lm.Meta[key] = fmt.Sprintf(format, v...)
+	return lm
+}
+
+func (lm *LogMessage) WithTraceStack(trace string) *LogMessage {
+	lm.trace = debughelper.TraceStack()
+	return lm
+}
+
+func (lm *LogMessage) WithCaller() *LogMessage {
+	lm.caller = debughelper.TraceCaller()
+	return lm
+}
+
+func (lm *LogMessage) String() string {
+	return fmt.Sprintf("%s %s %s",
+		lm.Timestamp.Format(time.RFC3339Nano),
+		lm.Msg,
+		lm.Meta,
+	)
+}

--- a/pkg/log/message.go
+++ b/pkg/log/message.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/lattesec/ctfjx/internal/helpers/debughelper"
@@ -39,7 +40,7 @@ func (lm *LogMessage) WithMetaf(key, format string, v ...any) *LogMessage {
 	return lm
 }
 
-func (lm *LogMessage) WithTraceStack(trace string) *LogMessage {
+func (lm *LogMessage) WithTraceStack() *LogMessage {
 	lm.trace = debughelper.TraceStack()
 	return lm
 }
@@ -50,9 +51,26 @@ func (lm *LogMessage) WithCaller() *LogMessage {
 }
 
 func (lm *LogMessage) String() string {
-	return fmt.Sprintf("%s %s %s",
+	var metaStr string
+	if len(lm.Meta) > 0 {
+		meta := make([]string, 0, len(lm.Meta))
+		for k, v := range lm.Meta {
+			meta = append(meta, fmt.Sprintf("%s=%s", k, v))
+		}
+		metaStr = fmt.Sprintf("{%s}", strings.Join(meta, ", "))
+	}
+
+	var debugStr string
+	if lm.trace != "" || lm.caller != "" {
+		debugStr = fmt.Sprintf("\n==== DEBUG ====\nCaller: %s\nTrace: %s", lm.caller, lm.trace) + "===== END =====\n"
+	}
+
+	return fmt.Sprintf("%s [%s] %s %s %s%s",
 		lm.Timestamp.Format(time.RFC3339Nano),
+		levelNames[lm.Level],
+		metaStr,
 		lm.Msg,
 		lm.Meta,
+		debugStr,
 	)
 }


### PR DESCRIPTION
[*] Major change
Logging previously worked by having a global mutex for I/O and FS I/O writes separately, meaning each log call was synchronously awaiting a lock which is pretty prone to deadlocks and slows things down quite a lot.

Now logging pushing logs into a 1024 buffered channel for I/O and FS I/O writes separately on each log call, if the channel overflows the log is dropped and thread immediately moves on. There are 2 goroutines handling for both outputs so we can avoid blocking on main thread as much as possible.

When the hot log file gets too big, we will now also gzip compress logs and wipe the current hot log file. (AKA. log rotations)

[*] Logging arch
Now we are able to spin up multiple logging handlers and still be able to have a global default logging handler.

[*] LogMessages
Per-Log LogLevel has been moved into a nice LogMessage struct we can chain method calls on.

[*] Cleanup handler (w/ panic recovery)

-----

Signed-off-by: AlexNg <contact@ngjx.org>